### PR TITLE
Use Nitter.net to retrieve tweets

### DIFF
--- a/gnus-twit.el
+++ b/gnus-twit.el
@@ -161,12 +161,13 @@
                     (replace-regexp-in-string "[@ ]+" ""
                                               (plist-get data :user-name))))
     (insert (format "Subject: %s\n"
-                    (mail-encode-encoded-word-string
-                     (gnus-twit-shorten
-                      (string-trim
-                       (replace-regexp-in-string
-                        "[ \t\n]+" " "
-                        (dom-texts (plist-get data :text))))))))
+                    (let ((rfc2047-encoding-type 'mime))
+                      (rfc2047-encode-string
+                       (gnus-twit-shorten
+                        (string-trim
+                         (replace-regexp-in-string
+                          "[ \t\n]+" " "
+                          (dom-texts (plist-get data :text)))))))))
     (insert (format "Message-ID: <%s@twitter.com>\n" status))
     (when parent
       (insert (format "References: <%s@twitter.com>\n" parent)))

--- a/gnus-twit.el
+++ b/gnus-twit.el
@@ -178,7 +178,15 @@
     (let ((start (point)))
       (dom-print (plist-get data :text))
       (encode-coding-region start (point) 'utf-8)
-      (quoted-printable-encode-region start (point)))
+      ;; There should not be any multibyte characters in the buffer at this
+      ;; point.  As `encode-coding-region' converts 8-bit bytes to their
+      ;; multibyte representation in multibyte buffers, switch to unibyte mode
+      ;; temporarily, to make `quoted-printable-encode-region' work (?).
+      ;; For example `’' should be encoded as `=E2=80=99', not
+      ;; `=3FFFE2=3FFF80=3FFF99'.
+      (set-buffer-multibyte nil)
+      (quoted-printable-encode-region start (point))
+      (set-buffer-multibyte 'to))
     (insert "\n\n")
     (insert (format "<p><img src=\"%s\">\n"
                     (plist-get data :avatar)))

--- a/gnus-twit.el
+++ b/gnus-twit.el
@@ -29,10 +29,10 @@
   (interactive "sTwitter URL: ")
   (let ((tmpfile (make-temp-file "gnus-temp-group-")))
     (unwind-protect
-	;; Add the debbugs address so that we can respond to reports easily.
+        ;; Add the debbugs address so that we can respond to reports easily.
         (let ((status (gnus-twit-status url))
-	      (threads (gnus-twit-build url)))
-	  (gnus-twit-make-mbox status threads tmpfile)
+              (threads (gnus-twit-build url)))
+          (gnus-twit-make-mbox status threads tmpfile)
           (gnus-group-read-ephemeral-group
            (concat "nndoc+ephemeral:twit#" status)
            `(nndoc ,tmpfile
@@ -48,8 +48,8 @@
    (with-current-buffer (url-retrieve-synchronously url)
      (goto-char (point-min))
      (prog1
-	 (when (re-search-forward "\r?\n\r?\n" nil t)
-	   (libxml-parse-html-region (point) (point-max)))
+         (when (re-search-forward "\r?\n\r?\n" nil t)
+           (libxml-parse-html-region (point) (point-max)))
        (kill-buffer (current-buffer))))
    t))
 
@@ -60,82 +60,82 @@
     (with-current-buffer (url-retrieve-synchronously url)
       (goto-char (point-min))
       (prog1
-	  (when (re-search-forward "\r?\n\r?\n" nil t)
-	    (gnus-twit-check url
-			     (libxml-parse-html-region (point) (point-max))
-			     threads))
-	(kill-buffer (current-buffer))))))
+          (when (re-search-forward "\r?\n\r?\n" nil t)
+            (gnus-twit-check url
+                             (libxml-parse-html-region (point) (point-max))
+                             threads))
+        (kill-buffer (current-buffer))))))
 
 (defun gnus-twit-check (url dom threads)
   (let ((tweets (gnus-twit-tweets dom)))
     (when tweets
       (if (equal (gnus-twit-status url) (gnus-twit-status (car tweets)))
-	  ;; We have the data for the first tweet in the thread; start
-	  ;; building.
-	  (gnus-twit-build-main dom threads)
-	(gnus-twit-build (concat "https://mobile.twitter.com" (car tweets)))))))
+          ;; We have the data for the first tweet in the thread; start
+          ;; building.
+          (gnus-twit-build-main dom threads)
+        (gnus-twit-build (concat "https://mobile.twitter.com" (car tweets)))))))
 
 (defun gnus-twit-build-main (dom threads)
   (let* ((main (dom-by-class dom "main-tweet"))
-	 (data (list :text `(div nil
-				 ,(dom-by-class main "tweet-text")
-				 ,(dom-by-class main "card-photo")
-				 ,(dom-by-class main "card-summary"))
-		     :date (string-trim
-			    (dom-texts
-			     (dom-by-class (dom-by-class main "tweet-content")
-					   "metadata")))
-		     :from (string-trim
-			    (dom-texts (dom-by-class main "fullname")))
-		     :user-name (string-trim
-				 (dom-texts (dom-by-class main "username")))
-		     :url (replace-regexp-in-string
-			   "/actions.*" ""
-			   (dom-attr
-			    (dom-by-tag (dom-by-class main "action-last") 'a)
-			    'href))
-		     :avatar (dom-attr
-			      (dom-by-tag (dom-by-class main "avatar") 'img)
-			      'src)
-		     :replies nil))
-	 (replies
-	  (cl-loop with replies
-		   for tweet in (dom-by-tag (dom-by-class dom "replies") 'table)
-		   when (or (null replies)
-			    (not (equal (dom-text
-					 (dom-by-class main "username"))
-					(plist-get data :user-name))))
-		   do (push (dom-attr tweet 'href) replies)
-		   finally (return (nreverse replies)))))
+         (data (list :text `(div nil
+                                 ,(dom-by-class main "tweet-text")
+                                 ,(dom-by-class main "card-photo")
+                                 ,(dom-by-class main "card-summary"))
+                     :date (string-trim
+                            (dom-texts
+                             (dom-by-class (dom-by-class main "tweet-content")
+                                           "metadata")))
+                     :from (string-trim
+                            (dom-texts (dom-by-class main "fullname")))
+                     :user-name (string-trim
+                                 (dom-texts (dom-by-class main "username")))
+                     :url (replace-regexp-in-string
+                           "/actions.*" ""
+                           (dom-attr
+                            (dom-by-tag (dom-by-class main "action-last") 'a)
+                            'href))
+                     :avatar (dom-attr
+                              (dom-by-tag (dom-by-class main "avatar") 'img)
+                              'src)
+                     :replies nil))
+         (replies
+          (cl-loop with replies
+                   for tweet in (dom-by-tag (dom-by-class dom "replies") 'table)
+                   when (or (null replies)
+                            (not (equal (dom-text
+                                         (dom-by-class main "username"))
+                                        (plist-get data :user-name))))
+                   do (push (dom-attr tweet 'href) replies)
+                   finally (return (nreverse replies)))))
     (setf (gethash (gnus-twit-status (plist-get data :url)) threads)
-	  data)
+          data)
     (plist-put data :replies (mapcar #'gnus-twit-status replies))
     (dolist (reply replies)
       (message "Fetching %s" (concat "https://mobile.twitter.com" reply))
       (unless (gethash (gnus-twit-status reply) threads)
-	(with-current-buffer (url-retrieve-synchronously
-			      (concat "https://mobile.twitter.com" reply)
-			      t)
-	  (let ((buffer (current-buffer)))
-	    (goto-char (point-min))
-	    (when (re-search-forward "\r?\n\r?\n" nil t)
-	      (gnus-twit-build-main
-	       (libxml-parse-html-region (point) (point-max))
-	       threads))
-	    (kill-buffer buffer)))))
+        (with-current-buffer (url-retrieve-synchronously
+                              (concat "https://mobile.twitter.com" reply)
+                              t)
+          (let ((buffer (current-buffer)))
+            (goto-char (point-min))
+            (when (re-search-forward "\r?\n\r?\n" nil t)
+              (gnus-twit-build-main
+               (libxml-parse-html-region (point) (point-max))
+               threads))
+            (kill-buffer buffer)))))
     threads))
 
 (defun gnus-twit-tweets (dom)
   (cl-loop for tweet in (dom-by-tag dom 'table)
-	   when (string-match "\\`tweet\\|\\`main-tweet"
-			      (or (dom-attr tweet 'class) ""))
-	   collect (replace-regexp-in-string
-		    "\\?.*" ""
-		    (or (dom-attr tweet 'href)
-			(dom-attr (dom-by-tag
-				   (dom-by-class tweet "action-last") 'a)
-				  'href)))))
-    
+           when (string-match "\\`tweet\\|\\`main-tweet"
+                              (or (dom-attr tweet 'class) ""))
+           collect (replace-regexp-in-string
+                    "\\?.*" ""
+                    (or (dom-attr tweet 'href)
+                        (dom-attr (dom-by-tag
+                                   (dom-by-class tweet "action-last") 'a)
+                                  'href)))))
+
 (defun gnus-twit-status (url)
   (and (string-match "/status/\\([0-9]+\\)" url)
        (match-string 1 url)))
@@ -157,21 +157,21 @@
     (remhash status threads)
     (insert (format "From twit@localhost Wed Aug 12 21:34:56 2020\n"))
     (insert (format "From: %s <%s@twitter.com>\n"
-		    (mail-encode-encoded-word-string (plist-get data :from))
-		    (replace-regexp-in-string "[@ ]+" ""
-					      (plist-get data :user-name))))
+                    (mail-encode-encoded-word-string (plist-get data :from))
+                    (replace-regexp-in-string "[@ ]+" ""
+                                              (plist-get data :user-name))))
     (insert (format "Subject: %s\n"
-		    (mail-encode-encoded-word-string
-		     (gnus-twit-shorten
-		      (string-trim
-		       (replace-regexp-in-string
-			"[ \t\n]+" " "
-			(dom-texts (plist-get data :text))))))))
+                    (mail-encode-encoded-word-string
+                     (gnus-twit-shorten
+                      (string-trim
+                       (replace-regexp-in-string
+                        "[ \t\n]+" " "
+                        (dom-texts (plist-get data :text))))))))
     (insert (format "Message-ID: <%s@twitter.com>\n" status))
     (when parent
       (insert (format "References: <%s@twitter.com>\n" parent)))
     (insert (format "Date: %s\n" (gnus-twit-format-date
-				  (plist-get data :date))))
+                                  (plist-get data :date))))
     (insert "Content-Transfer-Encoding: quoted-printable\n")
     (insert "Content-Type: text/html; charset=utf-8\n\n")
     (let ((start (point)))
@@ -180,9 +180,9 @@
       (quoted-printable-encode-region start (point)))
     (insert "\n\n")
     (insert (format "<p><img src=\"%s\">\n"
-		    (plist-get data :avatar)))
+                    (plist-get data :avatar)))
     (insert (format "<p><a href=\"https://twitter.com%s\">[Link]</a>\n\n"
-		    (plist-get data :url)))
+                    (plist-get data :url)))
     (insert "\n\n\n")
     (dolist (reply (plist-get data :replies))
       (gnus-twit-make-mbox-1 reply threads status))))
@@ -193,24 +193,24 @@
 
 (defun gnus-twit-format-date (string)
   (if (string-match "\\([0-9]+\\):\\([0-9]+\\) +\\([AP]M\\)[- ]+\\([0-9]+\\) +\\([A-Za-z]+\\) +\\([0-9]+\\)"
-		    string)
+                    string)
       (message-make-date
        (encode-time
-	(make-decoded-time :second 0
-			   :minute (string-to-number (match-string 2 string))
-			   :hour (+ (string-to-number (match-string 1 string))
-				    (if (equal (match-string 3 string) "PM")
-					(if (equal (match-string 1 string) "12")
-					    0
-					  12)
-				      (if (equal (match-string 1 string) "12")
-					  -12
-					12)))
-			   :day (string-to-number (match-string 4 string))
-			   :year (string-to-number (match-string 6 string))
-			   :month (1+ (seq-position gnus-twit-months
-						    (match-string 5 string)
-						    #'equal)))))
+        (make-decoded-time :second 0
+                           :minute (string-to-number (match-string 2 string))
+                           :hour (+ (string-to-number (match-string 1 string))
+                                    (if (equal (match-string 3 string) "PM")
+                                        (if (equal (match-string 1 string) "12")
+                                            0
+                                          12)
+                                      (if (equal (match-string 1 string) "12")
+                                          -12
+                                        12)))
+                           :day (string-to-number (match-string 4 string))
+                           :year (string-to-number (match-string 6 string))
+                           :month (1+ (seq-position gnus-twit-months
+                                                    (match-string 5 string)
+                                                    #'equal)))))
     string))
 
 (provide 'gnus-twit)


### PR DESCRIPTION
Hi Lars,

I saw your post on emacs.devel (I think? I can't seem to find the thread right now.) about `gnus-twit` and was (a) amused and (b) intrigued, because I also  dreamed of a Gnus interface to those long and winding Twitter threads. So I butchered your implementation to work with https://github.com/zedeus/nitter, an alternative Twitter front-end. Unfortunately they do not have a real API yet, but the content is served via static HTML pages, so it's easy to scrape.
It seems to work so far, at least for the threads I tried it with. But for example the way paginated replies are fetched now is not too elegant, as I just hacked that into the retrieve-replies loop.
W.r.t. the "fix encoding" commits: I'm not sure whether they're correct, but at least the text now looks fine for me. I sometimes get a "Malformed quoted-printable text" message, but I haven't investigated further.